### PR TITLE
Fix typo in public field standardSensitivity

### DIFF
--- a/src/main/java/mpicbg/spim/segmentation/InteractiveDoG.java
+++ b/src/main/java/mpicbg/spim/segmentation/InteractiveDoG.java
@@ -82,8 +82,8 @@ public class InteractiveDoG implements PlugIn
 	float threshold = 0.0001f;
 	
 	// steps per octave
-	public static int standardSenstivity = 4;
-	int sensitivity = standardSenstivity;
+	public static int standardSensitivity = 4;
+	int sensitivity = standardSensitivity;
 	
 	float imageSigma = 0.5f;
 	float sigmaMin = 0.5f;


### PR DESCRIPTION
I am aware that according to SemVer, this will require a major version bump because it changes the public API. I just bumped into this typo while scripting, so I thought I'll fix it here and leave it up to the maintainers to include it into the next major version...
