### PR TITLE
Allow concatenateAxialScaling to work with SimilarityModel3D

### DIFF
--- a/src/main/java/mpicbg/spim/registration/bead/BeadRegistration.java
+++ b/src/main/java/mpicbg/spim/registration/bead/BeadRegistration.java
@@ -18,6 +18,7 @@ import mpicbg.models.IllDefinedDataPointsException;
 import mpicbg.models.Model;
 import mpicbg.models.NotEnoughDataPointsException;
 import mpicbg.models.RigidModel3D;
+import mpicbg.models.SimilarityModel3D;
 import mpicbg.models.TranslationModel3D;
 import mpicbg.spim.io.IOFunctions;
 import mpicbg.spim.io.SPIMConfiguration;
@@ -627,6 +628,17 @@ public class BeadRegistration
 				              0f, 0f, z,  0f );
 				
 				((AffineModel3D)model).concatenate( tmpModel );
+			}
+			else if ( model instanceof SimilarityModel3D )
+			{
+				final SimilarityModel3D tmpModel = new SimilarityModel3D();
+				final float z = (float)zStretching;
+
+				tmpModel.set( 1f, 0f, 0f, 0f, 
+							  0f, 1f, 0f, 0f,
+							  0f, 0f, z,  0f );
+
+				((SimilarityModel3D)model).concatenate( tmpModel );
 			}
 			else if ( model instanceof RigidModel3D )
 			{


### PR DESCRIPTION
This requires the `SimilarityModel3D#set(double, double, double, ...)` method introduced in https://github.com/axtimwalde/mpicbg/pull/28, so a new release of `mpicbg.jar` is required before merging.

This PR fixes concatenation of axial scaling with `SimilarityModel3D` when using the _Descriptor-based (series) registration_ plugin in Fiji.