### PR TITLE
Progresswriterfix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>sc.fiji</groupId>
 		<artifactId>pom-fiji</artifactId>
-		<version>18.1.0</version>
+		<version>24.3.0</version>
 		<relativePath />
 	</parent>
 

--- a/src/main/java/mpicbg/spim/io/IOFunctions.java
+++ b/src/main/java/mpicbg/spim/io/IOFunctions.java
@@ -1,7 +1,5 @@
 package mpicbg.spim.io;
 
-import ij.IJ;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
@@ -11,6 +9,9 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 
+import bdv.export.ProgressWriter;
+import bdv.export.ProgressWriterConsole;
+import ij.IJ;
 import mpicbg.models.AbstractAffineModel3D;
 import mpicbg.models.AffineModel3D;
 import mpicbg.models.RigidModel3D;
@@ -23,6 +24,7 @@ import mpicbg.spim.registration.segmentation.NucleiConfiguration;
 import mpicbg.spim.registration.segmentation.Nucleus;
 import mpicbg.spim.registration.segmentation.NucleusIdentification;
 import net.imglib2.util.Util;
+import spim.fiji.plugin.resave.ProgressWriterIJ;
 
 public class IOFunctions
 {
@@ -58,6 +60,16 @@ public class IOFunctions
 			IJ.error( string );
 		else
 			System.err.println( string );
+	}
+
+	private static ProgressWriterIJ progressWriterIJ = new ProgressWriterIJ();
+	private static ProgressWriterConsole progressWriterConsole = new ProgressWriterConsole();
+	public static ProgressWriter getProgressWriter()
+	{
+		if ( printIJLog )
+			return progressWriterIJ;
+		else
+			return progressWriterConsole;
 	}
 
 	public static SPIMConfiguration initSPIMProcessing()

--- a/src/main/java/spim/fiji/spimdata/explorer/ViewSetupExplorerPanel.java
+++ b/src/main/java/spim/fiji/spimdata/explorer/ViewSetupExplorerPanel.java
@@ -25,6 +25,13 @@ import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 import javax.swing.table.DefaultTableCellRenderer;
 
+import bdv.BigDataViewer;
+import bdv.img.hdf5.Hdf5ImageLoader;
+import bdv.tools.InitializeViewerState;
+import bdv.tools.brightness.ConverterSetup;
+import bdv.viewer.DisplayMode;
+import bdv.viewer.ViewerOptions;
+import bdv.viewer.VisibilityAndGrouping;
 import mpicbg.spim.data.SpimDataException;
 import mpicbg.spim.data.generic.AbstractSpimData;
 import mpicbg.spim.data.generic.XmlIoAbstractSpimData;
@@ -58,12 +65,6 @@ import spim.fiji.spimdata.explorer.util.ColorStream;
 import spim.fiji.spimdata.interestpoints.InterestPointList;
 import spim.fiji.spimdata.interestpoints.ViewInterestPointLists;
 import spim.fiji.spimdata.interestpoints.ViewInterestPoints;
-import bdv.BigDataViewer;
-import bdv.img.hdf5.Hdf5ImageLoader;
-import bdv.tools.InitializeViewerState;
-import bdv.tools.brightness.ConverterSetup;
-import bdv.viewer.DisplayMode;
-import bdv.viewer.VisibilityAndGrouping;
 
 public class ViewSetupExplorerPanel< AS extends AbstractSpimData< ? >, X extends XmlIoAbstractSpimData< ?, AS > > extends JPanel
 {
@@ -137,7 +138,7 @@ public class ViewSetupExplorerPanel< AS extends AbstractSpimData< ? >, X extends
 			
 			if ( bdvpopup != null )
 			{
-				bdvpopup.bdv = new BigDataViewer( getSpimData(), xml(), IOFunctions.getProgressWriter() );
+				bdvpopup.bdv = BigDataViewer.open( getSpimData(), xml(), IOFunctions.getProgressWriter(), ViewerOptions.options() );
 
 //				if ( !bdv.tryLoadSettings( panel.xml() ) ) TODO: this should work, but currently tryLoadSettings is protected. fix that.
 					InitializeViewerState.initBrightness( 0.001, 0.999, bdvpopup.bdv.getViewer(), bdvpopup.bdv.getSetupAssignments() );

--- a/src/main/java/spim/fiji/spimdata/explorer/ViewSetupExplorerPanel.java
+++ b/src/main/java/spim/fiji/spimdata/explorer/ViewSetupExplorerPanel.java
@@ -137,7 +137,7 @@ public class ViewSetupExplorerPanel< AS extends AbstractSpimData< ? >, X extends
 			
 			if ( bdvpopup != null )
 			{
-				bdvpopup.bdv = new BigDataViewer( getSpimData(), xml(), null );
+				bdvpopup.bdv = new BigDataViewer( getSpimData(), xml(), IOFunctions.getProgressWriter() );
 
 //				if ( !bdv.tryLoadSettings( panel.xml() ) ) TODO: this should work, but currently tryLoadSettings is protected. fix that.
 					InitializeViewerState.initBrightness( 0.001, 0.999, bdvpopup.bdv.getViewer(), bdvpopup.bdv.getSetupAssignments() );

--- a/src/main/java/spim/fiji/spimdata/explorer/popup/BDVPopup.java
+++ b/src/main/java/spim/fiji/spimdata/explorer/popup/BDVPopup.java
@@ -106,7 +106,7 @@ public class BDVPopup extends JMenuItem implements ViewExplorerSetable
 				return null;
 		}
 
-		BigDataViewer bdv = new BigDataViewer( panel.getSpimData(), panel.xml(), null );
+		BigDataViewer bdv = new BigDataViewer( panel.getSpimData(), panel.xml(), IOFunctions.getProgressWriter() );
 //		if ( !bdv.tryLoadSettings( panel.xml() ) ) TODO: this should work, but currently tryLoadSettings is protected. fix that.
 			InitializeViewerState.initBrightness( 0.001, 0.999, bdv.getViewer(), bdv.getSetupAssignments() );
 		

--- a/src/main/java/spim/fiji/spimdata/explorer/popup/BDVPopup.java
+++ b/src/main/java/spim/fiji/spimdata/explorer/popup/BDVPopup.java
@@ -19,6 +19,7 @@ import bdv.BigDataViewer;
 import bdv.tools.InitializeViewerState;
 import bdv.tools.transformation.TransformedSource;
 import bdv.viewer.Source;
+import bdv.viewer.ViewerOptions;
 import bdv.viewer.ViewerPanel;
 import bdv.viewer.state.SourceState;
 import bdv.viewer.state.ViewerState;
@@ -106,7 +107,7 @@ public class BDVPopup extends JMenuItem implements ViewExplorerSetable
 				return null;
 		}
 
-		BigDataViewer bdv = new BigDataViewer( panel.getSpimData(), panel.xml(), IOFunctions.getProgressWriter() );
+		BigDataViewer bdv = BigDataViewer.open( panel.getSpimData(), panel.xml(), IOFunctions.getProgressWriter(), ViewerOptions.options() );
 //		if ( !bdv.tryLoadSettings( panel.xml() ) ) TODO: this should work, but currently tryLoadSettings is protected. fix that.
 			InitializeViewerState.initBrightness( 0.001, 0.999, bdv.getViewer(), bdv.getSetupAssignments() );
 		

--- a/src/main/java/spim/process/fusion/boundingbox/BigDataViewerBoundingBox.java
+++ b/src/main/java/spim/process/fusion/boundingbox/BigDataViewerBoundingBox.java
@@ -59,7 +59,7 @@ public class BigDataViewerBoundingBox extends BoundingBoxGUI
 					return null;
 			}
 
-			bdv = new BigDataViewer( spimData, "BigDataViewer", null );
+			bdv = new BigDataViewer( spimData, "BigDataViewer", IOFunctions.getProgressWriter() );
 			bdvIsLocal = true;
 
 //			if ( !bdv.tryLoadSettings( panel.xml() ) ) TODO: this should work, but currently tryLoadSettings is protected. fix that.

--- a/src/main/java/spim/process/fusion/boundingbox/BigDataViewerBoundingBox.java
+++ b/src/main/java/spim/process/fusion/boundingbox/BigDataViewerBoundingBox.java
@@ -11,6 +11,10 @@ import javax.swing.AbstractAction;
 import javax.swing.JButton;
 import javax.swing.JOptionPane;
 
+import bdv.BigDataViewer;
+import bdv.tools.InitializeViewerState;
+import bdv.tools.boundingbox.BoundingBoxDialog;
+import bdv.viewer.ViewerOptions;
 import mpicbg.spim.data.generic.AbstractSpimData;
 import mpicbg.spim.data.generic.sequence.BasicViewDescription;
 import mpicbg.spim.data.sequence.ViewId;
@@ -27,9 +31,6 @@ import spim.fiji.spimdata.explorer.ViewSetupExplorerPanel;
 import spim.fiji.spimdata.explorer.popup.BDVPopup;
 import spim.fiji.spimdata.imgloaders.AbstractImgLoader;
 import spim.process.fusion.export.ImgExport;
-import bdv.BigDataViewer;
-import bdv.tools.InitializeViewerState;
-import bdv.tools.boundingbox.BoundingBoxDialog;
 
 public class BigDataViewerBoundingBox extends BoundingBoxGUI
 {
@@ -59,7 +60,7 @@ public class BigDataViewerBoundingBox extends BoundingBoxGUI
 					return null;
 			}
 
-			bdv = new BigDataViewer( spimData, "BigDataViewer", IOFunctions.getProgressWriter() );
+			bdv = BigDataViewer.open( spimData, "BigDataViewer", IOFunctions.getProgressWriter(), ViewerOptions.options() );
 			bdvIsLocal = true;
 
 //			if ( !bdv.tryLoadSettings( panel.xml() ) ) TODO: this should work, but currently tryLoadSettings is protected. fix that.


### PR DESCRIPTION
Create BDV windows with a non-null ProgressWriter (required to make BDV movie recording dialogs work). The ProgressWriter is obtained by IOFunctions.getProgressWriter() which returns ProgressWriterConsole or ProgressWriterIJ depending on the IOFunctions.printIJLog flag.

Use BigDataViewer.open() instead of deprecated fixes.

This PR also bumps the pom-fiji parent version to pull in newest BDV and spim_data dependencies.