### PR TITLE
bump to pom-bigdataviewer 4.0.1 versions and fix compile errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,6 +112,7 @@
 
 	<properties>
 		<scijava.jvm.version>1.8</scijava.jvm.version>
+		<pom-bigdataviewer.version>4.0.1</pom-bigdataviewer.version>
 	</properties>
 
 	<repositories>

--- a/src/main/java/spim/process/fusion/export/AppendSpimData2HDF5.java
+++ b/src/main/java/spim/process/fusion/export/AppendSpimData2HDF5.java
@@ -165,7 +165,8 @@ public class AppendSpimData2HDF5 implements ImgExport
 		final boolean writeMipmapInfo = true; // TODO: remember whether we already wrote it and write only once
 		final boolean deflate = params.getDeflate();
 		final ProgressWriter progressWriter = new SubTaskProgressWriter( this.progressWriter, 0.0, 1.0 ); // TODO
-		WriteSequenceToHdf5.writeViewToHdf5PartitionFile( ushortimg, partition, tp.getId(), vs.getId(), mipmapInfo, writeMipmapInfo, deflate, null, null, progressWriter );
+		final int numThreads = Math.max( 1, Runtime.getRuntime().availableProcessors() - 2 );
+		WriteSequenceToHdf5.writeViewToHdf5PartitionFile( ushortimg, partition, tp.getId(), vs.getId(), mipmapInfo, writeMipmapInfo, deflate, null, null, numThreads, progressWriter );
 
 		// update the registrations
 		final ViewRegistration vr = spimData.getViewRegistrations().getViewRegistration( new ViewId( tp.getId(), vs.getId() ) );

--- a/src/main/java/spim/process/fusion/export/ExportSpimData2HDF5.java
+++ b/src/main/java/spim/process/fusion/export/ExportSpimData2HDF5.java
@@ -258,7 +258,8 @@ public class ExportSpimData2HDF5 implements ImgExport
 		final boolean writeMipmapInfo = true; // TODO: remember whether we already wrote it and write only once
 		final boolean deflate = params.getDeflate();
 		final ProgressWriter progressWriter = new SubTaskProgressWriter( this.progressWriter, 0.0, 1.0 ); // TODO
-		WriteSequenceToHdf5.writeViewToHdf5PartitionFile( ushortimg, partition, tp.getId(), vs.getId(), mipmapInfo, writeMipmapInfo, deflate, null, null, progressWriter );
+		final int numThreads = Math.max( 1, Runtime.getRuntime().availableProcessors() - 2 );
+		WriteSequenceToHdf5.writeViewToHdf5PartitionFile( ushortimg, partition, tp.getId(), vs.getId(), mipmapInfo, writeMipmapInfo, deflate, null, null, numThreads, progressWriter );
 
 		// update the registrations
 		final ViewRegistration vr = spimData.getViewRegistrations().getViewRegistration( new ViewId( tp.getId(), vs.getId() ) );


### PR DESCRIPTION
bump bdv versions to pom-bigdataviewer-4.0.1. This introduces API changes (mostly moving things around and removal of deprecated API) and this PR fixes resulting compile errors.