### PR TITLE
fix deadlock

### DIFF
--- a/src/main/java/mpicbg/spim/io/IOFunctions.java
+++ b/src/main/java/mpicbg/spim/io/IOFunctions.java
@@ -30,6 +30,8 @@ import java.util.Collection;
 import java.util.Date;
 import java.util.HashMap;
 
+import javax.swing.SwingUtilities;
+
 import bdv.export.ProgressWriter;
 import bdv.export.ProgressWriterConsole;
 import ij.IJ;
@@ -91,6 +93,36 @@ public class IOFunctions
 			return progressWriterIJ;
 		else
 			return progressWriterConsole;
+	}
+
+	public static void printlnSafe() { printlnSafe( "" ); }
+	public static void printlnSafe( final Object object) { printlnSafe( object.toString() ); }
+	public static void printlnSafe( final String string )
+	{
+		if ( printIJLog )
+		{
+			if ( SwingUtilities.isEventDispatchThread() )
+				IJ.log( string );
+			else
+				SwingUtilities.invokeLater( () -> IJ.log( string ) );
+		}
+		else
+			System.out.println( string );
+	}
+
+	public static void printErrSafe() { printErr( "" ); }
+	public static void printErrSafe( final Object object) { printErr( object.toString() ); }
+	public static void printErrSafe( final String string )
+	{
+		if ( printIJLog )
+		{
+			if ( SwingUtilities.isEventDispatchThread() )
+				IJ.error( string );
+			else
+				SwingUtilities.invokeLater( () -> IJ.error( string ) );
+		}
+		else
+			System.err.println( string );
 	}
 
 	public static SPIMConfiguration initSPIMProcessing()

--- a/src/main/java/spim/fiji/spimdata/explorer/popup/BDVPopup.java
+++ b/src/main/java/spim/fiji/spimdata/explorer/popup/BDVPopup.java
@@ -31,6 +31,16 @@ import java.util.List;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 
+import bdv.AbstractSpimSource;
+import bdv.BigDataViewer;
+import bdv.tools.InitializeViewerState;
+import bdv.tools.transformation.TransformedSource;
+import bdv.viewer.Source;
+import bdv.viewer.ViewerOptions;
+import bdv.viewer.ViewerPanel;
+import bdv.viewer.state.SourceState;
+import bdv.viewer.state.ViewerState;
+import mpicbg.spim.data.generic.sequence.BasicImgLoader;
 import mpicbg.spim.data.registration.ViewRegistration;
 import mpicbg.spim.io.IOFunctions;
 import net.imglib2.Interval;
@@ -39,16 +49,7 @@ import net.imglib2.util.LinAlgHelpers;
 import spim.fiji.plugin.apply.BigDataViewerTransformationWindow;
 import spim.fiji.spimdata.explorer.ViewSetupExplorerPanel;
 import spim.fiji.spimdata.imgloaders.AbstractImgLoader;
-import bdv.AbstractSpimSource;
-import bdv.BigDataViewer;
-import bdv.tools.InitializeViewerState;
-import bdv.tools.transformation.TransformedSource;
-import bdv.util.Affine3DHelpers;
-import bdv.viewer.Source;
-import bdv.viewer.ViewerOptions;
-import bdv.viewer.ViewerPanel;
-import bdv.viewer.state.SourceState;
-import bdv.viewer.state.ViewerState;
+import spim.fiji.spimdata.imgloaders.StackImgLoader;
 
 public class BDVPopup extends JMenuItem implements ViewExplorerSetable
 {
@@ -122,7 +123,8 @@ public class BDVPopup extends JMenuItem implements ViewExplorerSetable
 	}
 	public static BigDataViewer createBDV( final ViewSetupExplorerPanel< ?, ? > panel )
 	{
-		if ( AbstractImgLoader.class.isInstance( panel.getSpimData().getSequenceDescription().getImgLoader() ) )
+		BasicImgLoader il = panel.getSpimData().getSequenceDescription().getImgLoader();
+		if ( AbstractImgLoader.class.isInstance( il ) || StackImgLoader.class.isInstance( il ) )
 		{
 			if ( JOptionPane.showConfirmDialog( null,
 					"Opening <SpimData> dataset that is not suited for interactive browsing.\n" +

--- a/src/main/java/spim/fiji/spimdata/imgloaders/LegacyDHMImgLoader.java
+++ b/src/main/java/spim/fiji/spimdata/imgloaders/LegacyDHMImgLoader.java
@@ -205,12 +205,12 @@ public class LegacyDHMImgLoader extends AbstractImgLoader
 
 		if ( countDroppedFrames > 0 )
 		{
-			IOFunctions.println(
+			IOFunctions.printlnSafe(
 					"(" + new Date( System.currentTimeMillis() ) + "): WARNING!!! " + countDroppedFrames +
 					" DROPPED FRAME(s) in timepoint="  + timepoint + " channel=" + ampOrPhaseDirectory + " following slices:" );
 
 			for ( final int z : slices )
-				IOFunctions.println( "(" + new Date( System.currentTimeMillis() ) + "): sliceindex=" + z + ", slice=" + zPlanes.get( z ));
+				IOFunctions.printlnSafe( "(" + new Date( System.currentTimeMillis() ) + "): sliceindex=" + z + ", slice=" + zPlanes.get( z ));
 		}
 	}
 }

--- a/src/main/java/spim/fiji/spimdata/imgloaders/LegacyLightSheetZ1ImgLoader.java
+++ b/src/main/java/spim/fiji/spimdata/imgloaders/LegacyLightSheetZ1ImgLoader.java
@@ -122,13 +122,13 @@ public class LegacyLightSheetZ1ImgLoader extends AbstractImgFactoryImgLoader
 	@Override
 	protected void loadMetaData( final ViewId view )
 	{
-		IOFunctions.println( new Date( System.currentTimeMillis() ) + ": Loading metadata for Lightsheet Z1 imgloader not necessary." );
+		IOFunctions.printlnSafe( new Date( System.currentTimeMillis() ) + ": Loading metadata for Lightsheet Z1 imgloader not necessary." );
 	}
 
 	@Override
 	public void finalize()
 	{
-		IOFunctions.println( "Closing czi: " + cziFile );
+		IOFunctions.printlnSafe( "Closing czi: " + cziFile );
 
 		try
 		{
@@ -145,13 +145,13 @@ public class LegacyLightSheetZ1ImgLoader extends AbstractImgFactoryImgLoader
 	{
 		if ( meta == null )
 		{
-			IOFunctions.println( new Date( System.currentTimeMillis() ) + ": Investigating file '" + cziFile.getAbsolutePath() + "' (loading metadata)." );
+			IOFunctions.printlnSafe( new Date( System.currentTimeMillis() ) + ": Investigating file '" + cziFile.getAbsolutePath() + "' (loading metadata)." );
 
 			meta = new LightSheetZ1MetaData();
 
 			if ( !meta.loadMetaData( cziFile, true ) )
 			{
-				IOFunctions.println( "Failed to analyze file: '" + cziFile.getAbsolutePath() + "'." );
+				IOFunctions.printlnSafe( "Failed to analyze file: '" + cziFile.getAbsolutePath() + "'." );
 				meta = null;
 				isClosed = true;
 				return null;
@@ -212,7 +212,7 @@ public class LegacyLightSheetZ1ImgLoader extends AbstractImgFactoryImgLoader
 			{
 				if ( meta.getReader() == null )
 				{
-					IOFunctions.println( new Date( System.currentTimeMillis() ) + ": Opening '" + cziFile.getName() + "' for reading image data." );
+					IOFunctions.printlnSafe( new Date( System.currentTimeMillis() ) + ": Opening '" + cziFile.getName() + "' for reading image data." );
 					r.setId( cziFile.getAbsolutePath() );
 				}
 
@@ -225,7 +225,7 @@ public class LegacyLightSheetZ1ImgLoader extends AbstractImgFactoryImgLoader
 				r.setSeries( a.getId() );
 			}
 
-			IOFunctions.println(
+			IOFunctions.printlnSafe(
 					new Date( System.currentTimeMillis() ) + ": Reading image data from '" + cziFile.getName() + "' [" + dim[ 0 ] + "x" + dim[ 1 ] + "x" + dim[ 2 ] +
 					" angle=" + a.getName() + " ch=" + c.getName() + " illum=" + i.getName() + " tp=" + t.getName() + " type=" + meta.pixelTypeString() +
 					" img=" + img.getClass().getSimpleName() + "<" + type.getClass().getSimpleName() + ">]" );
@@ -285,8 +285,8 @@ public class LegacyLightSheetZ1ImgLoader extends AbstractImgFactoryImgLoader
 		}
 		catch ( Exception e )
 		{
-			IOFunctions.println( "File '" + cziFile.getAbsolutePath() + "' could not be opened: " + e );
-			IOFunctions.println( "Stopping" );
+			IOFunctions.printlnSafe( "File '" + cziFile.getAbsolutePath() + "' could not be opened: " + e );
+			IOFunctions.printlnSafe( "Stopping" );
 
 			e.printStackTrace();
 			try { r.close(); } catch (IOException e1) { e1.printStackTrace(); }

--- a/src/main/java/spim/fiji/spimdata/imgloaders/LegacyMicroManagerImgLoader.java
+++ b/src/main/java/spim/fiji/spimdata/imgloaders/LegacyMicroManagerImgLoader.java
@@ -106,10 +106,10 @@ public class LegacyMicroManagerImgLoader extends AbstractImgLoader
 
 		if ( countDroppedFrames > 0 )
 		{
-			IOFunctions.println( "(" + new Date( System.currentTimeMillis() ) + "): WARNING!!! " + countDroppedFrames + " DROPPED FRAME(s) in timepoint="  + t + " viewsetup=" + vd.getViewSetupId() + " following slices:" );
+			IOFunctions.printlnSafe( "(" + new Date( System.currentTimeMillis() ) + "): WARNING!!! " + countDroppedFrames + " DROPPED FRAME(s) in timepoint="  + t + " viewsetup=" + vd.getViewSetupId() + " following slices:" );
 
 			for ( final int z : slices )
-				IOFunctions.println( "(" + new Date( System.currentTimeMillis() ) + "): slice=" + z );
+				IOFunctions.printlnSafe( "(" + new Date( System.currentTimeMillis() ) + "): slice=" + z );
 		}
 	}
 
@@ -136,7 +136,7 @@ public class LegacyMicroManagerImgLoader extends AbstractImgLoader
 		}
 		catch ( Exception e )
 		{
-			IOFunctions.println( "Failed to load viewsetup=" + view.getViewSetupId() + " timepoint=" + view.getTimePointId() + ": " + e );
+			IOFunctions.printlnSafe( "Failed to load viewsetup=" + view.getViewSetupId() + " timepoint=" + view.getTimePointId() + ": " + e );
 			e.printStackTrace();
 			return null;
 		}
@@ -162,7 +162,7 @@ public class LegacyMicroManagerImgLoader extends AbstractImgLoader
 		}
 		catch ( Exception e )
 		{
-			IOFunctions.println( "Failed to load viewsetup=" + view.getViewSetupId() + " timepoint=" + view.getTimePointId() + ": " + e );
+			IOFunctions.printlnSafe( "Failed to load viewsetup=" + view.getViewSetupId() + " timepoint=" + view.getTimePointId() + ": " + e );
 			e.printStackTrace();
 			return null;
 		}
@@ -181,7 +181,7 @@ public class LegacyMicroManagerImgLoader extends AbstractImgLoader
 		}
 		catch ( Exception e )
 		{
-			IOFunctions.println( "Failed to load metadata for viewsetup=" + view.getViewSetupId() + " timepoint=" + view.getTimePointId() + ": " + e );
+			IOFunctions.printlnSafe( "Failed to load metadata for viewsetup=" + view.getViewSetupId() + " timepoint=" + view.getTimePointId() + ": " + e );
 			e.printStackTrace();
 		}
 	}

--- a/src/main/java/spim/fiji/spimdata/imgloaders/LegacySlideBook6ImgLoader.java
+++ b/src/main/java/spim/fiji/spimdata/imgloaders/LegacySlideBook6ImgLoader.java
@@ -126,13 +126,13 @@ public class LegacySlideBook6ImgLoader extends AbstractImgFactoryImgLoader
 	@Override
 	protected void loadMetaData( final ViewId view )
 	{
-		IOFunctions.println( new Date( System.currentTimeMillis() ) + ": Loading metadata for SlideBook6 imgloader not necessary." );
+		IOFunctions.printlnSafe( new Date( System.currentTimeMillis() ) + ": Loading metadata for SlideBook6 imgloader not necessary." );
 	}
 
 	@Override
 	public void finalize()
 	{
-		IOFunctions.println( "Closing sld: " + sldFile );
+		IOFunctions.printlnSafe( "Closing sld: " + sldFile );
 
 		try
 		{
@@ -149,13 +149,13 @@ public class LegacySlideBook6ImgLoader extends AbstractImgFactoryImgLoader
 	{
 		if ( meta == null )
 		{
-			IOFunctions.println( new Date( System.currentTimeMillis() ) + ": Investigating file '" + sldFile.getAbsolutePath() + "' (loading metadata)." );
+			IOFunctions.printlnSafe( new Date( System.currentTimeMillis() ) + ": Investigating file '" + sldFile.getAbsolutePath() + "' (loading metadata)." );
 
 			meta = new SlideBook6MetaData();
 
 			if ( !meta.loadMetaData( sldFile, true ) )
 			{
-				IOFunctions.println( "Failed to analyze file: '" + sldFile.getAbsolutePath() + "'." );
+				IOFunctions.printlnSafe( "Failed to analyze file: '" + sldFile.getAbsolutePath() + "'." );
 				meta = null;
 				isClosed = true;
 				return null;
@@ -233,7 +233,7 @@ public class LegacySlideBook6ImgLoader extends AbstractImgFactoryImgLoader
 		if ( img == null )
 			throw new RuntimeException( "Could not instantiate " + getImgFactory().getClass().getSimpleName() + " for '" + sldFile + "' captureId=" + c + "' viewId=" + view.getViewSetupId() + ", tpId=" + view.getTimePointId() + ", most likely out of memory." );
 
-		IOFunctions.println(
+		IOFunctions.printlnSafe(
 				new Date( System.currentTimeMillis() ) + ": Opening '" + sldFile.getName() + "' [" + dim[ 0 ] + "x" + dim[ 1 ] + "x" + dim[ 2 ] +
 						" angle=" + a.getName() + " ch=" + ch.getName() + " illum=" + i.getName() + " tp=" + t.getName() + " type=" + FormatTools.getPixelTypeString(FormatTools.UINT16) +
 						" img=" + img.getClass().getSimpleName() + "<" + type.getClass().getSimpleName() + ">]" );
@@ -262,7 +262,7 @@ public class LegacySlideBook6ImgLoader extends AbstractImgFactoryImgLoader
 			{
 				if ( meta.getReader() == null )
 				{
-					IOFunctions.println( new Date( System.currentTimeMillis() ) + ": Opening '" + sldFile.getName() + "' for reading image data." );
+					IOFunctions.printlnSafe( new Date( System.currentTimeMillis() ) + ": Opening '" + sldFile.getName() + "' for reading image data." );
 					r.setId( sldFile.getAbsolutePath() );
 				}
 
@@ -275,7 +275,7 @@ public class LegacySlideBook6ImgLoader extends AbstractImgFactoryImgLoader
 				r.setSeries( c );
 			}
 
-			IOFunctions.println(
+			IOFunctions.printlnSafe(
 					new Date( System.currentTimeMillis() ) + ": Reading image data from '" + sldFile.getName() + "' [" + dim[ 0 ] + "x" + dim[ 1 ] + "x" + dim[ 2 ] +
 					" angle=" + a.getName() + " ch=" + ch.getName() + " illum=" + i.getName() + " tp=" + t.getName() + " type=" + meta.pixelTypeString() +
 					" img=" + img.getClass().getSimpleName() + "<" + type.getClass().getSimpleName() + ">]" );
@@ -291,7 +291,7 @@ public class LegacySlideBook6ImgLoader extends AbstractImgFactoryImgLoader
 
 				r.openBytes( r.getIndex( z, chIndex, t.getId() ), b );
 
-				IOFunctions.println("reader.readImagePlaneBuf z = " + z + ", capture = " + c + ", angle = " + a.getId() +
+				IOFunctions.printlnSafe("reader.readImagePlaneBuf z = " + z + ", capture = " + c + ", angle = " + a.getId() +
 				", channel = " + (chIndex) + ", channels = " + meta.numChannels(c) + ", timepoint = " + t.getId());
 
 				// SlideBook6Reader.dll
@@ -309,8 +309,8 @@ public class LegacySlideBook6ImgLoader extends AbstractImgFactoryImgLoader
 		}
 		catch ( Exception e )
 		{
-			IOFunctions.println("File '" + sldFile.getAbsolutePath() + "' could not be opened: " + e);
-			IOFunctions.println( "Stopping" );
+			IOFunctions.printlnSafe("File '" + sldFile.getAbsolutePath() + "' could not be opened: " + e);
+			IOFunctions.printlnSafe( "Stopping" );
 
 			e.printStackTrace();
 			return null;

--- a/src/main/java/spim/fiji/spimdata/imgloaders/LegacyStackImgLoader.java
+++ b/src/main/java/spim/fiji/spimdata/imgloaders/LegacyStackImgLoader.java
@@ -102,10 +102,10 @@ public abstract class LegacyStackImgLoader extends AbstractImgFactoryImgLoader
 			if ( f.exists() )
 				return f;
 			else
-				IOFunctions.println( "File '" + f.getAbsolutePath() + "' does not exist." );
+				IOFunctions.printlnSafe( "File '" + f.getAbsolutePath() + "' does not exist." );
 		}
 
-		IOFunctions.println( "Could not find file for tp=" + timepoint + ", angle=" + angle + ", channel=" + channel + ", ill=" + illum );
+		IOFunctions.printlnSafe( "Could not find file for tp=" + timepoint + ", angle=" + angle + ", channel=" + channel + ", ill=" + illum );
 
 		return null;
 	}
@@ -162,18 +162,18 @@ public abstract class LegacyStackImgLoader extends AbstractImgFactoryImgLoader
 		if ( replaceAngles != null )
 			numDigitsAngles = replaceAngles.length() - 2;
 		/*
-		IOFunctions.println( replaceTimepoints );
-		IOFunctions.println( replaceChannels );
-		IOFunctions.println( replaceIlluminations );
-		IOFunctions.println( replaceAngles );
-		
-		IOFunctions.println( layoutTP );
-		IOFunctions.println( layoutChannels );
-		IOFunctions.println( layoutIllum );
-		IOFunctions.println( layoutAngles );
-		
-		IOFunctions.println( path );
-		IOFunctions.println( fileNamePattern );
-		*/		
+		IOFunctions.printlnSafe( replaceTimepoints );
+		IOFunctions.printlnSafe( replaceChannels );
+		IOFunctions.printlnSafe( replaceIlluminations );
+		IOFunctions.printlnSafe( replaceAngles );
+
+		IOFunctions.printlnSafe( layoutTP );
+		IOFunctions.printlnSafe( layoutChannels );
+		IOFunctions.printlnSafe( layoutIllum );
+		IOFunctions.printlnSafe( layoutAngles );
+
+		IOFunctions.printlnSafe( path );
+		IOFunctions.printlnSafe( fileNamePattern );
+		*/
 	}
 }

--- a/src/main/java/spim/fiji/spimdata/imgloaders/LegacyStackImgLoaderIJ.java
+++ b/src/main/java/spim/fiji/spimdata/imgloaders/LegacyStackImgLoaderIJ.java
@@ -69,7 +69,7 @@ public class LegacyStackImgLoaderIJ extends LegacyStackImgLoader
 
 		if ( imp == null )
 		{
-			IOFunctions.println( "Could not open file with ImageJ TIFF reader: '" + file.getAbsolutePath() + "'" );
+			IOFunctions.printlnSafe( "Could not open file with ImageJ TIFF reader: '" + file.getAbsolutePath() + "'" );
 			return null;
 		}
 
@@ -93,7 +93,7 @@ public class LegacyStackImgLoaderIJ extends LegacyStackImgLoader
 		if ( file == null )
 			throw new RuntimeException( "Could not find file '" + file + "'." );
 
-		IOFunctions.println( new Date( System.currentTimeMillis() ) + ": Loading '" + file + "' ..." );
+		IOFunctions.printlnSafe( new Date( System.currentTimeMillis() ) + ": Loading '" + file + "' ..." );
 
 		final ImagePlus imp = open( file );
 
@@ -106,7 +106,7 @@ public class LegacyStackImgLoaderIJ extends LegacyStackImgLoader
 		if ( img == null )
 			throw new RuntimeException( "Could not instantiate " + getImgFactory().getClass().getSimpleName() + " for '" + file + "', most likely out of memory." );
 		else
-			IOFunctions.println( new Date( System.currentTimeMillis() ) + ": Opened '" + file + "' [" + dim[ 0 ] + "x" + dim[ 1 ] + "x" + dim[ 2 ] + " image=" + img.getClass().getSimpleName() + "<FloatType>]" );
+			IOFunctions.printlnSafe( new Date( System.currentTimeMillis() ) + ": Opened '" + file + "' [" + dim[ 0 ] + "x" + dim[ 1 ] + "x" + dim[ 2 ] + " image=" + img.getClass().getSimpleName() + "<FloatType>]" );
 
 		imagePlus2ImgLib2Img( imp, img, normalize );
 
@@ -231,7 +231,7 @@ public class LegacyStackImgLoaderIJ extends LegacyStackImgLoader
 		if ( file == null )
 			throw new RuntimeException( "Could not find file '" + file + "'." );
 
-		IOFunctions.println( new Date( System.currentTimeMillis() ) + ": Loading '" + file + "' ..." );
+		IOFunctions.printlnSafe( new Date( System.currentTimeMillis() ) + ": Loading '" + file + "' ..." );
 
 		final ImagePlus imp = open( file );
 
@@ -244,7 +244,7 @@ public class LegacyStackImgLoaderIJ extends LegacyStackImgLoader
 		if ( imp.getType() == ImagePlus.GRAY32 )
 		{
 			is32bit = true;
-			IOFunctions.println( new Date( System.currentTimeMillis() ) + ": Image '" + file + "' is 32bit, opening as 16bit with scaling" );
+			IOFunctions.printlnSafe( new Date( System.currentTimeMillis() ) + ": Image '" + file + "' is 32bit, opening as 16bit with scaling" );
 
 			if ( params == null )
 				params = queryParameters();
@@ -267,7 +267,7 @@ public class LegacyStackImgLoaderIJ extends LegacyStackImgLoader
 		if ( img == null )
 			throw new RuntimeException( "Could not instantiate " + getImgFactory().getClass().getSimpleName() + " for '" + file + "', most likely out of memory." );
 		else
-			IOFunctions.println( new Date( System.currentTimeMillis() ) + ": Opened '" + file + "' [" + dim[ 0 ] + "x" + dim[ 1 ] + "x" + dim[ 2 ] + " image=" + img.getClass().getSimpleName() + "<UnsignedShortType>]" );
+			IOFunctions.printlnSafe( new Date( System.currentTimeMillis() ) + ": Opened '" + file + "' [" + dim[ 0 ] + "x" + dim[ 1 ] + "x" + dim[ 2 ] + " image=" + img.getClass().getSimpleName() + "<UnsignedShortType>]" );
 
 		final ImageStack stack = imp.getStack();
 		final int sizeZ = imp.getStack().getSize();

--- a/src/main/java/spim/fiji/spimdata/imgloaders/LegacyStackImgLoaderLOCI.java
+++ b/src/main/java/spim/fiji/spimdata/imgloaders/LegacyStackImgLoaderLOCI.java
@@ -192,7 +192,7 @@ public class LegacyStackImgLoaderLOCI extends LegacyStackImgLoader
 
 			if ( imp2d.getStack().getSize() > 1 )
 			{
-				IOFunctions.println( "This is not a two-dimensional file: '" + path + "'" );
+				IOFunctions.printlnSafe( "This is not a two-dimensional file: '" + path + "'" );
 				imp2d.close();
 				return null;
 			}
@@ -202,7 +202,7 @@ public class LegacyStackImgLoaderLOCI extends LegacyStackImgLoader
 			if ( output == null )
 				throw new RuntimeException( "Could not instantiate " + getImgFactory().getClass().getSimpleName() + " for '" + path + "', most likely out of memory." );
 
-			IOFunctions.println( new Date( System.currentTimeMillis() ) + ": Opening '" + path + "' [" + imp2d.getWidth() + "x" + imp2d.getHeight() + "x" + depth + " type=" +
+			IOFunctions.printlnSafe( new Date( System.currentTimeMillis() ) + ": Opening '" + path + "' [" + imp2d.getWidth() + "x" + imp2d.getHeight() + "x" + depth + " type=" +
 					imp2d.getProcessor().getClass().getSimpleName() + " image=" + output.getClass().getSimpleName() + "<" + type.getClass().getSimpleName() + ">]" );
 
 			for ( int z = 0; z < depth; ++z )
@@ -260,7 +260,7 @@ public class LegacyStackImgLoaderLOCI extends LegacyStackImgLoader
 			if ( cal == 0 )
 			{
 				cal = 1;
-				IOFunctions.println( "StackListLOCI: Warning, calibration for dimension X seems corrupted, setting to 1." );
+				IOFunctions.printlnSafe( "StackListLOCI: Warning, calibration for dimension X seems corrupted, setting to 1." );
 			}
 			calX = cal;
 
@@ -268,7 +268,7 @@ public class LegacyStackImgLoaderLOCI extends LegacyStackImgLoader
 			if ( cal == 0 )
 			{
 				cal = 1;
-				IOFunctions.println( "StackListLOCI: Warning, calibration for dimension Y seems corrupted, setting to 1." );
+				IOFunctions.printlnSafe( "StackListLOCI: Warning, calibration for dimension Y seems corrupted, setting to 1." );
 			}
 			calY = cal;
 
@@ -276,13 +276,13 @@ public class LegacyStackImgLoaderLOCI extends LegacyStackImgLoader
 			if ( cal == 0 )
 			{
 				cal = 1;
-				IOFunctions.println( "StackListLOCI: Warning, calibration for dimension Z seems corrupted, setting to 1." );
+				IOFunctions.printlnSafe( "StackListLOCI: Warning, calibration for dimension Z seems corrupted, setting to 1." );
 			}
 			calZ = cal;
 		}
 		catch ( Exception e )
 		{
-			IOFunctions.println( "Failed to read calibration, setting to 1x1x1um." );
+			IOFunctions.printlnSafe( "Failed to read calibration, setting to 1x1x1um." );
 			calX = calY = calZ = 1;
 		}
 
@@ -314,7 +314,7 @@ public class LegacyStackImgLoaderLOCI extends LegacyStackImgLoader
 
 		if (!(pixelType == FormatTools.UINT8 || pixelType == FormatTools.UINT16 || pixelType == FormatTools.UINT32 || pixelType == FormatTools.FLOAT))
 		{
-			IOFunctions.println( "StackImgLoaderLOCI.openLOCI(): PixelType " + pixelTypeString + " not supported by " +
+			IOFunctions.printlnSafe( "StackImgLoaderLOCI.openLOCI(): PixelType " + pixelTypeString + " not supported by " +
 					type.getClass().getSimpleName() + ", returning. ");
 
 			r.close();
@@ -332,7 +332,7 @@ public class LegacyStackImgLoaderLOCI extends LegacyStackImgLoader
 			throw new RuntimeException( "Could not instantiate " + getImgFactory().getClass().getSimpleName() + " for '" + path + "', most likely out of memory." );
 		}
 		else
-			IOFunctions.println( new Date( System.currentTimeMillis() ) + ": Opening '" + path + "' [" + width + "x" + height + "x" + depth + " ch=" + c + " tp=" + t + " type=" + pixelTypeString + " image=" + img.getClass().getSimpleName() + "<" + type.getClass().getSimpleName() + ">]" );
+			IOFunctions.printlnSafe( new Date( System.currentTimeMillis() ) + ": Opening '" + path + "' [" + width + "x" + height + "x" + depth + " ch=" + c + " tp=" + t + " type=" + pixelTypeString + " image=" + img.getClass().getSimpleName() + "<" + type.getClass().getSimpleName() + ">]" );
 
 		final byte[] b = new byte[width * height * bytesPerPixel];
 
@@ -510,7 +510,7 @@ public class LegacyStackImgLoaderLOCI extends LegacyStackImgLoader
 			if ( cal == 0 )
 			{
 				cal = 1;
-				IOFunctions.println( "StackListLOCI: Warning, calibration for dimension X seems corrupted, setting to 1." );
+				IOFunctions.printlnSafe( "StackListLOCI: Warning, calibration for dimension X seems corrupted, setting to 1." );
 			}
 			final double calX = cal;
 
@@ -521,7 +521,7 @@ public class LegacyStackImgLoaderLOCI extends LegacyStackImgLoader
 			if ( cal == 0 )
 			{
 				cal = 1;
-				IOFunctions.println( "StackListLOCI: Warning, calibration for dimension Y seems corrupted, setting to 1." );
+				IOFunctions.printlnSafe( "StackListLOCI: Warning, calibration for dimension Y seems corrupted, setting to 1." );
 			}
 			final double calY = cal;
 
@@ -532,11 +532,11 @@ public class LegacyStackImgLoaderLOCI extends LegacyStackImgLoader
 			if ( cal == 0 )
 			{
 				cal = 1;
-				IOFunctions.println( "StackListLOCI: Warning, calibration for dimension Z seems corrupted, setting to 1." );
+				IOFunctions.printlnSafe( "StackListLOCI: Warning, calibration for dimension Z seems corrupted, setting to 1." );
 			}
 			final double calZ = cal;
 
-			IOFunctions.println( "Image stack size of first stack: " + r.getSizeX() + "x" + r.getSizeY() + "x" + r.getSizeZ() );
+			IOFunctions.printlnSafe( "Image stack size of first stack: " + r.getSizeX() + "x" + r.getSizeY() + "x" + r.getSizeZ() );
 
 			final Calibration calibration = new Calibration( r.getSizeX(), r.getSizeY(), r.getSizeZ(), calX, calY, calZ );
 
@@ -546,7 +546,7 @@ public class LegacyStackImgLoaderLOCI extends LegacyStackImgLoader
 		}
 		catch ( Exception e)
 		{
-			IOFunctions.println( "Could not open file: '" + file.getAbsolutePath() + "'" );
+			IOFunctions.printlnSafe( "Could not open file: '" + file.getAbsolutePath() + "'" );
 			e.printStackTrace();
 			return null;
 		}

--- a/src/main/java/spim/fiji/spimdata/imgloaders/MultipageTiffReader.java
+++ b/src/main/java/spim/fiji/spimdata/imgloaders/MultipageTiffReader.java
@@ -151,14 +151,14 @@ public class MultipageTiffReader
 				lastDisplayedFile = "";
 
 			if ( !lastDisplayedFile.equals( file.getAbsolutePath() ) )
-				IOFunctions.println( "Using the following files for the MicroManager ImgLoader: " );
+				IOFunctions.printlnSafe( "Using the following files for the MicroManager ImgLoader: " );
 
 			for ( i = 0; i < this.files.size(); ++i )
 			{
 				final File f = this.files.get( i );
 
 				if ( !lastDisplayedFile.equals( file.getAbsolutePath() ) )
-					IOFunctions.println( f.getAbsolutePath() );
+					IOFunctions.printlnSafe( f.getAbsolutePath() );
 
 				this.raFiles.add( new RandomAccessFile( f, "rw" ) );
 				this.fileChannels.add( this.raFiles.get( this.raFiles.size() - 1 ).getChannel() );
@@ -245,7 +245,7 @@ public class MultipageTiffReader
 				byteDepth_ = 2;
 			}
 		} catch (Exception ex) {
-			IOFunctions.println(ex);
+			IOFunctions.printlnSafe(ex);
 		}
 	}
 
@@ -259,7 +259,7 @@ public class MultipageTiffReader
 
 			if ( fileChannel == null )
 			{
-				IOFunctions.println( "Attempted to read image on FileChannel that is null" );
+				IOFunctions.printlnSafe( "Attempted to read image on FileChannel that is null" );
 				return null;
 			}
 
@@ -272,13 +272,13 @@ public class MultipageTiffReader
 			}
 			catch ( IOException ex )
 			{
-				IOFunctions.println(ex);
+				IOFunctions.printlnSafe(ex);
 				return null;
 			}
 		}
 		else
 		{
-			IOFunctions.println( "Exception: label '" + label + "' not in present in hashmap, cannot read data." );
+			IOFunctions.printlnSafe( "Exception: label '" + label + "' not in present in hashmap, cannot read data." );
 			// label not in map--either writer hasnt finished writing it
 			return null;
 		}
@@ -301,7 +301,7 @@ public class MultipageTiffReader
 
 			if ( header != SUMMARY_MD_HEADER )
 			{
-				IOFunctions.println( "Summary Metadata Header Incorrect" );
+				IOFunctions.printlnSafe( "Summary Metadata Header Incorrect" );
 				return false;
 			}
 
@@ -311,7 +311,7 @@ public class MultipageTiffReader
 			final HashMap< String, Object > summaryMD = parseJSONSimple( getString( mdBuffer ) );
 
 			if ( summaryMD == null )
-				IOFunctions.println( "Couldn't read summary Metadata from file: " + getFileForFileChannel( fileChannel ).getName() );
+				IOFunctions.printlnSafe( "Couldn't read summary Metadata from file: " + getFileForFileChannel( fileChannel ).getName() );
 
 			// MVRotationAxis = 0_1_0
 			// MVRotations = 0_90_0_90
@@ -341,7 +341,7 @@ public class MultipageTiffReader
 		{
 			ex.printStackTrace();
 
-			IOFunctions.println( "Couldn't read summary Metadata from file: " + getFileForFileChannel( fileChannel ).getName() );
+			IOFunctions.printlnSafe( "Couldn't read summary Metadata from file: " + getFileForFileChannel( fileChannel ).getName() );
 			return false;
 		}
 	}
@@ -372,7 +372,7 @@ public class MultipageTiffReader
 		{
 			if ( !jsonString.startsWith( "\"" ) )
 			{
-				IOFunctions.println( "Failed to parse json string: " + json );
+				IOFunctions.printlnSafe( "Failed to parse json string: " + json );
 				return null;
 			}
 
@@ -463,7 +463,7 @@ public class MultipageTiffReader
 			// current version
 			final String label = generateLabel( channel, slice, frame, position );
 			if ( indexMap_.containsKey( label ) )
-				IOFunctions.println( "ERROR!!! Label: " + label + " already present." );
+				IOFunctions.printlnSafe( "ERROR!!! Label: " + label + " already present." );
 
 			//System.out.println( label + " " + getFileForFileChannel( fileChannel ).getName() );
 
@@ -507,7 +507,7 @@ public class MultipageTiffReader
 		try {
 			return new String(buffer.array(), "UTF-8");
 		} catch (UnsupportedEncodingException ex) {
-			IOFunctions.println(ex);
+			IOFunctions.printlnSafe(ex);
 			return "";
 		}
 	}
@@ -526,7 +526,7 @@ public class MultipageTiffReader
 
 		if ( rgb_ )
 		{
-			IOFunctions.println( "RGB types not supported." );
+			IOFunctions.printlnSafe( "RGB types not supported." );
 			return null;
 		}
 		else
@@ -691,7 +691,7 @@ public class MultipageTiffReader
 	{
 		if ( angleId < 0 || angleId >= numAngles() )
 		{
-			IOFunctions.println( "No angle with id " + angleId + ", there are only " + numAngles() + " angles." );
+			IOFunctions.printlnSafe( "No angle with id " + angleId + ", there are only " + numAngles() + " angles." );
 			return String.valueOf( angleId );
 		}
 
@@ -710,7 +710,7 @@ public class MultipageTiffReader
 		}
 		catch ( Exception e )
 		{
-			IOFunctions.println( "Failed to get rotation angle: " + e );
+			IOFunctions.printlnSafe( "Failed to get rotation angle: " + e );
 			return "0";
 		}
 	}
@@ -724,7 +724,7 @@ public class MultipageTiffReader
 	{
 		if ( channelId < 0 || channelId >= numChannels() )
 		{
-			IOFunctions.println( "No channel with id " + channelId + ", there are only " + numChannels() + " channels." );
+			IOFunctions.printlnSafe( "No channel with id " + channelId + ", there are only " + numChannels() + " channels." );
 			return String.valueOf( channelId );
 		}
 
@@ -744,7 +744,7 @@ public class MultipageTiffReader
 	
 			if ( entries.length != numChannelsAndAngles() )
 			{
-				IOFunctions.println( "Number of entries in " + summaryMetadata_.get( "ChNames" ).toString().trim() + " does not match numAngles()*numChannels()=" + numChannelsAndAngles() );
+				IOFunctions.printlnSafe( "Number of entries in " + summaryMetadata_.get( "ChNames" ).toString().trim() + " does not match numAngles()*numChannels()=" + numChannelsAndAngles() );
 				return String.valueOf( channelId );
 			}
 
@@ -757,7 +757,7 @@ public class MultipageTiffReader
 		}
 		catch ( Exception e )
 		{
-			IOFunctions.println( "Failed to parse channel name: " + e );
+			IOFunctions.printlnSafe( "Failed to parse channel name: " + e );
 			return String.valueOf( channelId );
 		}
 	}


### PR DESCRIPTION
This fixes a deadlock that occurs sometimes when showing non-hdf5 data in BDV in dataset explorer.

`IJ.log()` does AWT things, which caused a deadlock sometimes:
* AWT thread in BDV box overlay needs to know image size, wants to acquires lock on `SpimSource` for that.
* Other thread at the same time is already loading the (same) image and holds the `SpimSource` lock for that. While loading the `ImgLoader` wants to log something, ultimately via `IJ.log`. `IJ.log` wants `AWTTreeLock` ... Deadlock.

Solution is to call `IJ.log` and `IJ.error` on the event dispatch thread. I did this now only for the imageloaders, it seems overkill to do it for everything.