### PR TITLE
allow metadata field to be a JSON object

### DIFF
--- a/src/main/java/spim/fiji/spimdata/imgloaders/MultipageTiffReader.java
+++ b/src/main/java/spim/fiji/spimdata/imgloaders/MultipageTiffReader.java
@@ -385,6 +385,10 @@ public class MultipageTiffReader
 			{
 				valueEnd = jsonString.indexOf( ']' ) + 1;
 			}
+			else if ( jsonString.charAt( valueStart ) == '{' )
+			{
+				valueEnd = jsonString.indexOf( '}' ) + 1;
+			}
 			else if ( jsonString.charAt( valueStart ) == '\"' )
 			{
 				++valueStart;


### PR DESCRIPTION
Micro-Manager metadata can contain JSON-encoded strings as a field value, which breaks the parseJSONSimple() method.  This edit allows the value of a field to be another JSON object without any attempt to parse that object, just like provision is made for a field value to be an array with no attempt to parse the array contents.  See http://json.org/ for details of the JSON syntax.

I haven't made any attempt to build this code and test it, but the edit seems straightforward enough.  I'm happy to provide an example Micro-Manager tif image file with metadata that breaks the existing code and thus can't currently be used with Fiji MVR (this PR should resolve the issue).