### PR TITLE
Fixes to the Micro-Manager reader

### DIFF
--- a/src/main/java/spim/fiji/spimdata/imgloaders/MultipageTiffReader.java
+++ b/src/main/java/spim/fiji/spimdata/imgloaders/MultipageTiffReader.java
@@ -385,7 +385,8 @@ public class MultipageTiffReader
 			{
 				valueEnd = jsonString.indexOf( ']' ) + 1;
 			}
-			else if ( jsonString.charAt( valueStart + 1) == '{' )
+			else if ( valueStart + 1 < jsonString.length() && 
+						jsonString.charAt( valueStart + 1) == '{' )
 			{
 				valueEnd = jsonString.indexOf( "}\"" ) + 2;
 			}

--- a/src/main/java/spim/fiji/spimdata/imgloaders/MultipageTiffReader.java
+++ b/src/main/java/spim/fiji/spimdata/imgloaders/MultipageTiffReader.java
@@ -385,9 +385,9 @@ public class MultipageTiffReader
 			{
 				valueEnd = jsonString.indexOf( ']' ) + 1;
 			}
-			else if ( jsonString.charAt( valueStart ) == '{' )
+			else if ( jsonString.charAt( valueStart + 1) == '{' )
 			{
-				valueEnd = jsonString.indexOf( '}' ) + 1;
+				valueEnd = jsonString.indexOf( "}\"" ) + 2;
 			}
 			else if ( jsonString.charAt( valueStart ) == '\"' )
 			{


### PR DESCRIPTION
JSON arrays were not correctly parsed.  Jon Daniels tried to fix this, but an exception was still thrown in the parseJSONSimple function.  The current code parsed the one file I had to test correctly.  The change is trivial and only touches the parseJSONSimple function in theMultiPageTiffReader class.